### PR TITLE
Fixed "Object.fromEntries is not a function" in "init-api-routes.js"

### DIFF
--- a/_remake/lib/init-api-routes.js
+++ b/_remake/lib/init-api-routes.js
@@ -128,7 +128,7 @@ export function initApiRoutes ({app}) {
     let referrerUrlParsed = new URL(referrerUrl);
     let referrerUrlPath = referrerUrlParsed.pathname; // e.g. "/jane/todo-list/123"
     let params = getParamsFromPathname(referrerUrlPath); // e.g. { username: 'jane', id: '123' }
-    let query = Object.fromEntries(referrerUrlParsed.searchParams);
+    let query = referrerUrlParsed.searchParams;
 
     let usernameFromParams = params.username;
     let pathname = referrerUrlPath;


### PR DESCRIPTION
When adding a new Todo it threw the following error:
```
(node:15631) UnhandledPromiseRejectionWarning: TypeError: Object.fromEntries is not a function
    at app.post (/home/andrew/Coding/Node.JS/remake-framework/_remake/lib/init-api-routes.js:131:24)
    at Layer.handle [as handle_request] (/home/andrew/Coding/Node.JS/remake-framework/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/andrew/Coding/Node.JS/remake-framework/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/home/andrew/Coding/Node.JS/remake-framework/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/home/andrew/Coding/Node.JS/remake-framework/node_modules/express/lib/router/layer.js:95:5)
    at /home/andrew/Coding/Node.JS/remake-framework/node_modules/express/lib/router/index.js:281:22
    at Function.process_params (/home/andrew/Coding/Node.JS/remake-framework/node_modules/express/lib/router/index.js:335:12)
    at next (/home/andrew/Coding/Node.JS/remake-framework/node_modules/express/lib/router/index.js:275:10)
    at SessionStrategy.strategy.pass (/home/andrew/Coding/Node.JS/remake-framework/node_modules/passport/lib/middleware/authenticate.js:338:9)
    at /home/andrew/Coding/Node.JS/remake-framework/node_modules/passport/lib/strategies/session.js:69:12
(node:15631) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:15631) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
Removed the unknown function and kept the variable `referrerUrlParsed.searchParams`.
That seemed to have fixed the problem.