### PR TITLE
Handle deleted files and directories when creating distribution

### DIFF
--- a/asset-bundler/index.js
+++ b/asset-bundler/index.js
@@ -1,5 +1,5 @@
 const chokidar = require("chokidar");
-const {processFile} = require("./process-file");
+const {deleteFile, deleteDir, processFile} = require("./process-file");
 const {runInitialBuild} = require("./run-initial-build");
 const config = require("./config");
 const {globToSearch, frameworkGlobToSearch} = config;
@@ -13,7 +13,17 @@ const watcher = chokidar.watch(globToSearch, {
 });
 
 watcher.on("all", (event, filePath, stats) => {
-  processFile({filePath, stats, shouldRecompute: true});
+  const fileInfo = {filePath, stats, shouldRecompute: true};
+  switch (event) {
+    case 'unlink':
+      deleteFile(fileInfo);
+      break;
+    case 'unlinkDir':
+      deleteDir(fileInfo);
+      break;
+    default:
+      processFile(fileInfo);
+  }
 });
 
 

--- a/asset-bundler/process-file.js
+++ b/asset-bundler/process-file.js
@@ -4,13 +4,13 @@ const mkdirp = require("mkdirp");
 const fs = require("fs");
 const glob = require("glob");
 const config = require("./config");
+const rimraf = require("rimraf");
 const {globToSearch, isMultiTenant} = config;
 
 function processFile ({filePath, stats, shouldRecompute, isProduction}) {
   filePath = "./" + filePath;
 
-  let isJsFile = path.extname(filePath) === ".js";
-  let isSassFile = [".sass", ".scss"].includes(path.extname(filePath));
+  let {isJsFile, isSassFile} = getFileType(filePath);
   let isDirectory = stats.isDirectory();
   let {distDir, distFilePath, distFileName, distMinFileName, fileStartsWithUnderscore} = getValidDestinationPath({filePath, isJsFile, isSassFile, isDirectory});
   let isFileToBeCopied = !fileStartsWithUnderscore && !isDirectory && !isJsFile && !isSassFile;
@@ -46,6 +46,33 @@ function processFile ({filePath, stats, shouldRecompute, isProduction}) {
   }
 }
 
+function deleteFile({filePath, shouldRecompute}) {
+  filePath = "./" + filePath;
+
+  const {isJsFile, isSassFile} = getFileType(filePath);
+  const {distFilePath, fileStartsWithUnderscore} = getValidDestinationPath({filePath, isJsFile, isSassFile, isDirectory: false});
+  const isFileToBeCopied = !fileStartsWithUnderscore && !isJsFile && !isSassFile;
+
+  if (fs.existsSync(distFilePath)) {
+    fs.unlinkSync(distFilePath);
+  }
+
+  // recompile all files of the same type if file starts with an underscore
+  //
+  // TODO: Should isProduction always be false? Filesystem events are only
+  // handled in development, but what happens when a production bundle is
+  // created that contains deleted files?
+  if ((isJsFile || isSassFile) && fileStartsWithUnderscore && shouldRecompute) {
+    recompileFilesForApp({filePath, isJsFile, isSassFile, isProduction: false});
+  }
+}
+
+function deleteDir({filePath, shouldRecompute}) {
+  filePath = "./" + filePath;
+
+  const {distFilePath} = getValidDestinationPath({filePath, isJsFile: false, isSassFile: false, isDirectory: true});
+  rimraf.sync(distFilePath, {disableGlob: true});
+}
 
 function recompileFilesForApp ({filePath, isJsFile, isSassFile, isProduction}) {
   let indexOfAssetsString = filePath.indexOf("/assets/");
@@ -109,6 +136,14 @@ function getValidDestinationPath ({filePath, isSassFile, isJsFile, isDirectory})
   return {distDir, distFilePath, distFileName, distMinFileName, fileStartsWithUnderscore};
 }
 
+function getFileType(filePath) {
+  const isJsFile = path.extname(filePath) === ".js";
+  const isSassFile = [".sass", ".scss"].includes(path.extname(filePath));
+  return {isJsFile, isSassFile};
+}
+
 module.exports = {
-  processFile
+  processFile,
+  deleteFile,
+  deleteDir,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -921,6 +921,17 @@
         "@parcel/utils": "^1.11.0",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.6.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@parcel/logger": {
@@ -7081,6 +7092,16 @@
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
         "tar": "^4"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "node-releases": {
@@ -9651,9 +9672,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
       "requires": {
         "glob": "^7.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "path-match": "^1.2.4",
+    "rimraf": "3.0.0",
     "session-file-store": "^1.3.1",
     "shelljs": "^0.8.3",
     "sortablejs": "^1.10.1",


### PR DESCRIPTION
The current implementation of processFile() does not handle "unlink" and "unlinkDir" filesystem events. When a file or directory is deleted, an exception is thrown.

To reproduce:

- `touch app/assets/js/foo.js`
- `rm app/assets/js/foo.js`

Two bad things happen:

- An exception is thrown
- The file is never deleted from `_remake/dist/`

This is especially problematic for CSS and JS files that begin with `_` because the bundle is not recreated when files like that are deleted.

This PR does a few things:

- Handles `unlink` and `unlinkDir` filesystem events separately from file updates
- If an individual file is removed that was also copied to `dist/`, the file is removed from `dist/`
- If an individual CSS/JS file is removed, the respective CSS/JS is also rebuilt
- If a directory is removed, the directory is removed from `dist/`